### PR TITLE
properly assign privacyidea realm if requested

### DIFF
--- a/privacyidea.lua
+++ b/privacyidea.lua
@@ -74,7 +74,7 @@ function privacyidea_validate(username, password)
     local params = {user = username, pass = password}
     local realm = ngx.var.privacyidea_realm or nil
     if realm then
-        params['realm'] = auth_realm
+        params['realm'] = realm
     end
 
     -- send request


### PR DESCRIPTION
There is a typo in the variable name used for overriding the privacyidea realm name.