### PR TITLE
Use lua-resty-http instead of ngx.location.capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ cache the result for a defined lifetime.
 Redis is providing the server side cache (for successful HTTP Basic
 Authentications) similar to the privacyIDEA apache2 authentication module.
 
-The lua script only requires the basic nginx-lua, lua-nginx-redis and
-lua-cjson module to be available
+The lua script requires the basic nginx-lua, lua-cjson, lua-nginx-redis and
+lua-resty-http modules to be available.
 
 Configuration
 -------------

--- a/privacyidea.lua
+++ b/privacyidea.lua
@@ -70,6 +70,8 @@ end
 
 function privacyidea_validate(username, password)
 
+    local httpc = require("resty.http").new()
+
     -- prepare parameter
     local params = {user = username, pass = password}
     local realm = ngx.var.privacyidea_realm or nil
@@ -78,12 +80,18 @@ function privacyidea_validate(username, password)
     end
 
     -- send request
-    ngx.req.set_header('Content-Type', 'application/x-www-form-urlencoded')
     local uri = ngx.var.privacyidea_uri or '/privacyidea-validate-check'
-    local res = ngx.location.capture(uri, {
-        method = ngx.HTTP_POST,
-        body = ngx.encode_args(params)
+
+    local res, err = httpc:request_uri(uri, {
+        method = "POST",
+        body = ngx.encode_args(params),
+        headers = {
+            ["Content-Type"] = "application/x-www-form-urlencoded",
+        },
     })
+    if not res then
+        return false, 'privacyIDEA HTTP Request Error ' .. err
+    end
 
     if res.status ~= 200 then
         return false, 'privacyIDEA HTTP Status ' .. res.status


### PR DESCRIPTION
This allows this snippet to also work when NGINX has HTTP/2 support
enabled.

Closes: #5